### PR TITLE
- Sequence along observations instead of columns

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,4 +51,4 @@ Encoding: UTF-8
 LazyData: true
 LazyLoad: yes
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1

--- a/R/sperrorest_resampling.R
+++ b/R/sperrorest_resampling.R
@@ -683,7 +683,7 @@ partition_kmeans <- function(data, coords = c("x", "y"), nfold = 10,
 
 #' @title Leave-one-disc-out cross-validation and leave-one-out cross-validation
 #'
-#' @description partition_disc` partitions the sample into training and tests
+#' @description `partition_disc` partitions the sample into training and tests
 #'   set by selecting circular test areas (possibly surrounded by an exclusion
 #'   buffer) and using the remaining samples as training samples
 #'   (leave-one-disc-out cross-validation). `partition_loo` creates training and

--- a/R/sperrorest_resampling.R
+++ b/R/sperrorest_resampling.R
@@ -773,7 +773,7 @@ partition_disc <- function(data,
       set.seed(seed1 + cnt) # nocov
     }
     if (ndisc == nrow(data)) {
-      index <- c(seq_along(data)) # nocov
+      index <- seq_len(nrow(data)) # nocov
     } else {
       index <- sample.int(nrow(data),
         size = ndisc, replace = replace,
@@ -799,7 +799,7 @@ partition_disc <- function(data,
         test_sel <- i
         if (return_train) {
           if (is.null(buffer)) {
-            train_sel <- c(seq_along(data))[-i] # nocov
+            train_sel <- seq_len(nrow(data))[-i] # nocov
           } else {
             train_sel <- which(di > posbuf)
           }
@@ -1271,6 +1271,7 @@ represampling_disc_bootstrap <- function(data,
 #' @export
 plot.represampling <- function(x, data, coords = c("x", "y"), pch = "+",
                                wiggle_sd = 0, ...) {
+
   # nocov start
   if (missing(data)) {
     stop("'data' argument missing")
@@ -1293,6 +1294,7 @@ plot.represampling <- function(x, data, coords = c("x", "y"), pch = "+",
     mfrow = c(nr, nc), mar = c(2, 2, 3, 0.5), mgp = c(2, 0.7, 0), tcl = -0.3,
     cex = 0.5
   )
+
   for (i in seq_along(resample)) {
     for (j in seq_along(resample[[i]])) {
       seltrain <- resample[[i]][[j]]$train

--- a/man/partition_disc.Rd
+++ b/man/partition_disc.Rd
@@ -61,7 +61,10 @@ objects. Each of these contains \code{ndisc} lists with indices of test and (if
 \code{return_train = TRUE}) training sets.
 }
 \description{
-partition_disc\verb{partitions the sample into training and tests set by selecting circular test areas (possibly surrounded by an exclusion buffer) and using the remaining samples as training samples (leave-one-disc-out cross-validation).}partition_loo` creates training and
+\code{partition_disc} partitions the sample into training and tests
+set by selecting circular test areas (possibly surrounded by an exclusion
+buffer) and using the remaining samples as training samples
+(leave-one-disc-out cross-validation). \code{partition_loo} creates training and
 test sets for leave-one-out cross-validation with (optional) buffer.
 }
 \note{

--- a/tests/testthat/test-sperrorest-resampling.R
+++ b/tests/testthat/test-sperrorest-resampling.R
@@ -77,11 +77,8 @@ test_that("partition_disc() output is of correct length", {
 test_that("partition_loo() output is of correct length", {
 
   data(ecuador)
-  parti <- partition_loo(ecuador,
-    buffer = 200,
-    ndisc = 5, repetition = 1:1
-  )
-  expect_equal(length(parti[[1]]), 5)
+  parti <- partition_loo(ecuador)
+  expect_equal(length(parti[[1]]), 751)
 })
 
 # represampling_bootstrap() Mon Feb  6 22:29:03 2017 ---------------------------


### PR DESCRIPTION
fixes #59 

``` r
library(sperrorest)

parti <- partition_loo(ecuador, buffer = 500)

parti[[1]] <- parti[[1]][1:3]
class(parti) <- "represampling"

plot(parti, ecuador)
```

![](https://i.imgur.com/SBvJ7y4.png)

<sup>Created on 2021-04-10 by the [reprex package](https://reprex.tidyverse.org) (v1.0.0)</sup>